### PR TITLE
Improve Byte-Order-Mark handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    subber (0.1.5)
+    subber (0.1.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/subber/parser/srt.rb
+++ b/lib/subber/parser/srt.rb
@@ -62,9 +62,9 @@ module Subber::Parser
       # @raise  [Subber::Errors::InvalidCounter]
       #
       def extract_counter(text)
-        raise(Subber::Errors::InvalidCounter) if text.match(COUNTER_REGEX).nil?
-        text.sub!(BYTE_ORDER_MARK_STRING, '')
-        text.to_i
+        counter_text = text.match(COUNTER_REGEX).to_a.first
+        raise(Subber::Errors::InvalidCounter) if counter_text.nil?
+        counter_text.to_i
       end
 
       # @param  text [String]

--- a/lib/subber/parser/srt.rb
+++ b/lib/subber/parser/srt.rb
@@ -1,13 +1,12 @@
 module Subber::Parser
   class Srt < Base
     SUBTITLE_REGEX = /([^\n]*)\n([^\n]*)(\n(.*))?/m
-    COUNTER_REGEX = /\d+/
+    COUNTER_REGEX = /(\d+)$/
     TIME_RANGE_REGEX = /(\d{2}:\d{2}:\d{2},\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2},\d{3})/
     TIMECODE_REGEX = /(\d{2}):(\d{2}):(\d{2}),(\d{3})/
 
     DELIMITER_REGEX = /\n?\n\n/
     WINDOW_LINE_BREAK_REGEX = /\r/
-    BYTE_ORDER_MARK_STRING = "\xEF\xBB\xBF"
 
     class << self
       # @param file_content [String]
@@ -62,7 +61,7 @@ module Subber::Parser
       # @raise  [Subber::Errors::InvalidCounter]
       #
       def extract_counter(text)
-        counter_text = text.match(COUNTER_REGEX).to_a.first
+        counter_text = text.match(COUNTER_REGEX).to_a.last
         raise(Subber::Errors::InvalidCounter) if counter_text.nil?
         counter_text.to_i
       end

--- a/lib/subber/version.rb
+++ b/lib/subber/version.rb
@@ -1,3 +1,3 @@
 module Subber
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
The `sub!` method encounters encoding issue
```
Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8
```