### PR TITLE
Add support for TTML

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     subber (0.2.3)
-      nokogiri
+      nokogiri (~> 1)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,7 @@ GEM
     diff-lcs (1.3)
     method_source (0.9.0)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.2)
+    nokogiri (1.9.1)
       mini_portile2 (~> 2.4.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -42,4 +42,4 @@ DEPENDENCIES
   subber!
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    subber (0.2.3)
+    subber (0.3.0)
       nokogiri (~> 1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     subber (0.2.3)
+      nokogiri
 
 GEM
   remote: https://rubygems.org/
@@ -9,6 +10,9 @@ GEM
     coderay (1.1.2)
     diff-lcs (1.3)
     method_source (0.9.0)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.2)
+      mini_portile2 (~> 2.4.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -38,4 +42,4 @@ DEPENDENCIES
   subber!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+## Changelog
+
+### `0.x.x`
+
+#### `0.3.x`
+
+- `0.3.0`: Add support for Timed Text Markup Language (TTML)
+
+#### `0.2.x`
+
+- `0.2.3`: Only reject json subtitle if content is nil
+- `0.2.2`: Fix timestamp parser + Add error message
+- `0.2.1`: Fix missing counter issue
+- `0.2.0`: Add support for json + Introduce generic interfaces for files and parsers
+
+#### `0.1.x`
+
+- `0.1.0`: Add support for vtt and srt
+
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/viki-org/subber-gem. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/subber.rb
+++ b/lib/subber.rb
@@ -10,6 +10,7 @@ require 'subber/formatter/base'
 require 'subber/formatter/json'
 require 'subber/formatter/srt'
 require 'subber/formatter/vtt'
+require 'subber/formatter/ttml'
 
 # Parsers
 #
@@ -17,6 +18,7 @@ require 'subber/parser/base'
 require 'subber/parser/json'
 require 'subber/parser/srt'
 require 'subber/parser/vtt'
+require 'subber/parser/ttml'
 
 # Files
 #
@@ -24,6 +26,7 @@ require 'subber/file/base'
 require 'subber/file/json'
 require 'subber/file/srt'
 require 'subber/file/vtt'
+require 'subber/file/ttml'
 require 'subber/file'
 
 module Subber; end

--- a/lib/subber/errors.rb
+++ b/lib/subber/errors.rb
@@ -6,6 +6,7 @@ module Subber::Errors
   class InvalidVttFormat < InvalidContent; end
   class InvalidSrtFormat < InvalidContent; end
   class InvalidJsonFormat < InvalidContent; end
+  class InvalidTtmlFormat < InvalidContent; end
 
   class InvalidCounter < InvalidContent; end
   class InvalidTimeRange < InvalidContent; end

--- a/lib/subber/file.rb
+++ b/lib/subber/file.rb
@@ -8,6 +8,8 @@ module Subber::File
         Subber::File::Vtt.from_content(content)
       when 'json'
         Subber::File::Json.from_content(content)
+      when 'ttml'
+        Subber::File::Ttml.from_content(content)
       else
         message = "#{format} is not a supported source subtitle format"
         raise(Subber::Errors::NotSupported, message)

--- a/lib/subber/file/base.rb
+++ b/lib/subber/file/base.rb
@@ -79,6 +79,8 @@ module Subber::File
         to_json
       when 'vtt'
         to_vtt
+      when 'ttml'
+        to_ttml
       else
         message = "#{file_type} is not a supported file type"
         raise(Subber::Errors::NotSupported, message)
@@ -101,6 +103,12 @@ module Subber::File
     #
     def to_vtt
       Subber::File::Vtt.new(subtitles: subtitles)
+    end
+
+    # @return [Subber::File::Ttml]
+    #
+    def to_ttml
+      Subber::File::Ttml.new(subtitles: subtitles)
     end
 
     private

--- a/lib/subber/file/ttml.rb
+++ b/lib/subber/file/ttml.rb
@@ -1,0 +1,8 @@
+# Timed Text Markup Language 1
+#
+module Subber::File
+  class Ttml < Base
+    parser Subber::Parser::Ttml
+    formatter Subber::Formatter::Ttml
+  end
+end

--- a/lib/subber/formatter/ttml.rb
+++ b/lib/subber/formatter/ttml.rb
@@ -15,7 +15,7 @@ module Subber::Formatter
           xml.tt(xmlns: XML_NAMESPACE) do
             xml.body do
               subtitles.each do |subtitle|
-                generate_subtitle_cue(subtitle, attach_to: xml)
+                generate_subtitle_cue(subtitle, insert_into: xml)
               end
             end
           end
@@ -26,11 +26,11 @@ module Subber::Formatter
 
       private
 
-      # @param  subtitle [Subtitle]
-      # @param  attach_to [XmlTag]
+      # @param  subtitle [Subber::Subtitle]
+      # @param  insert_into [Nokogiri::XML::Builder]
       #
-      def generate_subtitle_cue(subtitle, attach_to: nil)
-        xml = attach_to
+      def generate_subtitle_cue(subtitle, insert_into: nil)
+        xml = insert_into
 
         begin_str = format_milisecond(subtitle.start_time)
         end_str = format_milisecond(subtitle.end_time)

--- a/lib/subber/formatter/ttml.rb
+++ b/lib/subber/formatter/ttml.rb
@@ -1,0 +1,55 @@
+require 'nokogiri'
+
+# Timed Text Markup Language 1
+#
+module Subber::Formatter
+  class Ttml < Base
+    XML_NAMESPACE = 'http://www.w3.org/ns/ttml'
+
+    class << self
+      # @param  subtitles [Array<Subber::Subtitle>]
+      # @return [String]
+      #
+      def format(subtitles)
+        builder = Nokogiri::XML::Builder.new do |xml|
+          xml.tt(xmlns: XML_NAMESPACE) do
+            xml.body do
+              subtitles.each do |subtitle|
+                generate_subtitle_cue(subtitle, attach_to: xml)
+              end
+            end
+          end
+        end
+
+        builder.to_xml
+      end
+
+      private
+
+      # @param  subtitle [Subtitle]
+      # @param  attach_to [XmlTag]
+      #
+      def generate_subtitle_cue(subtitle, attach_to: nil)
+        xml = attach_to
+
+        begin_str = format_milisecond(subtitle.start_time)
+        end_str = format_milisecond(subtitle.end_time)
+
+        xml.div(begin: begin_str, end: end_str) do
+          xml.p do
+            xml.text subtitle.content
+          end
+        end
+
+        nil
+      end
+
+      # @param  ms_duration [Integer] Time duration in milisecond
+      # @return [String] "1000ms"
+      #
+      def format_milisecond(ms_duration)
+        "#{ms_duration}ms"
+      end
+    end
+  end
+end

--- a/lib/subber/parser/ttml.rb
+++ b/lib/subber/parser/ttml.rb
@@ -4,8 +4,6 @@ module Subber::Parser
   class Ttml < Base
     attr_reader :raw_content
 
-    CUE_CSS_PATH = 'body'.freeze
-
     class << self
       # @param  content [String]
       # @return [Array<Subber::Subtitle>]

--- a/lib/subber/parser/ttml.rb
+++ b/lib/subber/parser/ttml.rb
@@ -1,0 +1,14 @@
+module Subber::Parser
+  class Ttml < Base
+    attr_reader :raw_content
+
+    class << self
+      # @param content [String]
+      # @return [Array<Subber::Subtitle>]
+      #
+      def parse(_content)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/subber/parser/ttml.rb
+++ b/lib/subber/parser/ttml.rb
@@ -4,12 +4,66 @@ module Subber::Parser
   class Ttml < Base
     attr_reader :raw_content
 
+    CUE_CSS_PATH = 'body'.freeze
+
     class << self
-      # @param content [String]
+      # @param  content [String]
       # @return [Array<Subber::Subtitle>]
       #
-      def parse(_content)
-        raise NotImplementedError
+      def parse(content)
+        doc = Nokogiri::XML(content)
+
+        cue_elements = doc.css('body > div, body > p')
+
+        cue_elements.each_with_index.map do |cue_element, index|
+          counter = index + 1
+          convert_xml_element_to_subtitle(cue_element, counter)
+        end
+      end
+
+      private
+
+      # @param  element [Nokogiri::XML::Element]
+      # @param  counter [Integer] sequence number
+      # @return [Subber::Subtitle]
+      #
+      def convert_xml_element_to_subtitle(element, counter)
+        begin_str = element.attribute('begin').value
+        end_str = element.attribute('end').value
+        content = element.text.strip
+
+        start_time = parse_milisecond(begin_str)
+        end_time = parse_milisecond(end_str)
+
+        Subber::Subtitle.new(
+          counter: counter,
+          start_time: start_time,
+          end_time: end_time,
+          content: content
+        )
+      end
+
+      # @param  time_string [String] e.g. 100ms, 5s
+      # @return [Integer] duration in milisecond
+      #
+      def parse_milisecond(time_string)
+        regex = /(\d+)(\w+)/
+        match_data = time_string.match(regex)
+
+        message = "#{time_string} is not a valid timestamp"
+
+        raise(Subber::Errors::InvalidTimestamp, message) unless match_data
+
+        _time_string, number, unit = match_data.to_a
+
+        case unit
+        when 's'
+          number.to_i * 1000
+        when 'ms'
+          number.to_i
+        else
+          raise(Subber::Errors::InvalidTimestamp, message)
+        end
       end
     end
   end

--- a/lib/subber/parser/ttml.rb
+++ b/lib/subber/parser/ttml.rb
@@ -1,3 +1,5 @@
+require 'nokogiri'
+
 module Subber::Parser
   class Ttml < Base
     attr_reader :raw_content

--- a/lib/subber/parser/ttml.rb
+++ b/lib/subber/parser/ttml.rb
@@ -13,6 +13,10 @@ module Subber::Parser
 
         cue_elements = doc.css('body > div, body > p')
 
+        if cue_elements.empty?
+          raise(Subber::Errors::InvalidTtmlFormat, 'no valid subtitle')
+        end
+
         cue_elements.each_with_index.map do |cue_element, index|
           counter = index + 1
           convert_xml_element_to_subtitle(cue_element, counter)

--- a/lib/subber/parser/ttml.rb
+++ b/lib/subber/parser/ttml.rb
@@ -49,7 +49,7 @@ module Subber::Parser
       # @return [Integer] duration in milisecond
       #
       def parse_milisecond(time_string)
-        regex = /(\d+)(\w+)/
+        regex = /^(\d+)(\w+)$/
         match_data = time_string.match(regex)
 
         message = "#{time_string} is not a valid timestamp"

--- a/lib/subber/version.rb
+++ b/lib/subber/version.rb
@@ -1,3 +1,3 @@
 module Subber
-  VERSION = '0.2.3'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/fixtures/ttml-sample-invalid-timestamp.xml
+++ b/spec/fixtures/ttml-sample-invalid-timestamp.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<tt xmlns="http://www.w3.org/ns/ttml">
+  <body>
+    <div begin="500ms" end="random-timestamp">
+      <p>this is a sample</p>
+    </div>
+    <div begin="4099ms" end="6000ms">
+      <p>subtitle for subber gem</p>
+    </div>
+  </body>
+</tt>

--- a/spec/fixtures/ttml-sample.xml
+++ b/spec/fixtures/ttml-sample.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<tt xmlns="http://www.w3.org/ns/ttml">
+  <body>
+    <div begin="500ms" end="4000ms">
+      <p>this is a sample</p>
+    </div>
+    <div begin="4099ms" end="6000ms">
+      <p>subtitle for subber gem</p>
+    </div>
+  </body>
+</tt>

--- a/spec/formatter/ttml_spec.rb
+++ b/spec/formatter/ttml_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Subber::Formatter::Ttml do
+  describe '.format' do
+    let(:subtitle1) do
+      Subber::Subtitle.new(
+        counter: 1,
+        start_time: 500,
+        end_time: 4000,
+        content: 'this is a sample'
+      )
+    end
+
+    let(:subtitle2) do
+      Subber::Subtitle.new(
+        counter: 2,
+        start_time: 4099,
+        end_time: 6000,
+        content: 'subtitle for subber gem'
+      )
+    end
+
+    let(:subtitles) { [subtitle1, subtitle2] }
+    let(:expected_content) { read_fixture('ttml-sample.xml') }
+
+    subject { described_class.format(subtitles) }
+
+    it { should eq(expected_content) }
+  end
+end

--- a/spec/parser/ttml_spec.rb
+++ b/spec/parser/ttml_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Subber::Parser::Ttml do
+  describe '.parse' do
+    subject { described_class.parse(content) }
+
+    context 'valid content' do
+      let(:content) { read_fixture('ttml-sample.xml') }
+      let(:expected_attribute_hashes) do
+        [
+          {
+            counter: 1,
+            start_time: 500,
+            end_time: 4000,
+            content: 'this is a sample',
+          },
+          {
+            counter: 2,
+            start_time: 4099,
+            end_time: 6000,
+            content: 'subtitle for subber gem',
+          }
+        ]
+      end
+
+      it 'generates subtitles based on the file content' do
+        subtitles = subject
+
+        subtitles.each_with_index do |subtitle, index|
+          attribute_hash = expected_attribute_hashes[index]
+          expect(subtitle).to have_attributes(attribute_hash)
+        end
+      end
+    end
+  end
+end

--- a/spec/parser/ttml_spec.rb
+++ b/spec/parser/ttml_spec.rb
@@ -4,6 +4,22 @@ describe Subber::Parser::Ttml do
   describe '.parse' do
     subject { described_class.parse(content) }
 
+    context 'invalid content' do
+      let(:content) { read_fixture('srt-sample.srt') }
+
+      it 'raises error' do
+        expect { subject }.to raise_error(Subber::Errors::InvalidTtmlFormat)
+      end
+    end
+
+    context 'invalid timestamp' do
+      let(:content) { read_fixture('ttml-sample-invalid-timestamp.xml') }
+
+      it 'raises error' do
+        expect { subject }.to raise_error(Subber::Errors::InvalidTimestamp)
+      end
+    end
+
     context 'valid content' do
       let(:content) { read_fixture('ttml-sample.xml') }
       let(:expected_attribute_hashes) do

--- a/subber.gemspec
+++ b/subber.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "subber/version"
@@ -34,4 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.11"
+
+  # XML parser and builder
+  #
+  spec.add_dependency "nokogiri"
 end

--- a/subber.gemspec
+++ b/subber.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
 
   # XML parser and builder
   #
-  spec.add_dependency "nokogiri"
+  spec.add_dependency "nokogiri", "~> 1"
 end


### PR DESCRIPTION
`ttml` stands for `Timed Text Markup Language 1` which is stored in XML format.

- [x] `Subber::File::Ttml`
- [x] `Subber::Formatter::Ttml`
- [x] `Subber::Parser::Ttml`

### Examples

```xml
<?xml version="1.0"?>
<tt xmlns="http://www.w3.org/ns/ttml">
  <body>
    <div begin="500ms" end="4000ms">
      <p>this is a sample</p>
    </div>
    <div begin="4099ms" end="6000ms">
      <p>subtitle for subber gem</p>
    </div>
  </body>
</tt>
```