### PR TITLE
[Security patch] Upgrade nokogiri and require ruby>=2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.6
+  - 2.5
+  - 2.7
 before_install: gem install bundler -v 1.16.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: ruby
 rvm:
   - 2.5
   - 2.7
-before_install: gem install bundler -v 1.16.1
+before_install: gem install bundler:1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,11 +37,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 1.17.1)
   pry (~> 0.11)
   rake (~> 10.0)
   rspec (~> 3.0)
   subber!
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    subber (0.3.2)
-      nokogiri (~> 1.10.4)
+    subber (0.3.3)
+      nokogiri (~> 1.12.3)
 
 GEM
   remote: https://rubygems.org/
@@ -10,12 +10,14 @@ GEM
     coderay (1.1.2)
     diff-lcs (1.3)
     method_source (0.9.0)
-    mini_portile2 (2.4.0)
-    nokogiri (1.10.4)
-      mini_portile2 (~> 2.4.0)
+    mini_portile2 (2.6.1)
+    nokogiri (1.12.3)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    racc (1.5.2)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 #### `0.3.x`
 
+- `0.3.3`: [Security Patch] Upgrade `nokogiri` to `1.12.3` + Add `2.5` as minimum ruby verison requirement
 - `0.3.2`: [Security Patch] Upgrade `nokogiri` to `1.10.4` + Add `2.3` as minimum ruby verison requirement
 - `0.3.1`: Allow subtitle in json file to have `nil` content
 - `0.3.0`: Add support for Timed Text Markup Language (TTML)

--- a/cloudbuild.test.yml
+++ b/cloudbuild.test.yml
@@ -10,11 +10,11 @@ steps:
 
   - id: retrieveTesterImage
     waitFor: ['-']
-    name: 'gcr.io/${PROJECT_ID}/ruby:2.3'
+    name: 'gcr.io/${PROJECT_ID}/ruby:2.5'
     entrypoint: bash
 
   - id: completeProvisioning
-    name: 'gcr.io/${PROJECT_ID}/ruby:2.3'
+    name: 'gcr.io/${PROJECT_ID}/ruby:2.5'
     waitFor:
       - 'retrieveBundlerTestCache'
       - 'retrieveTesterImage'
@@ -26,7 +26,7 @@ steps:
 
   - id: updateTestBundler
     waitFor: ['completeProvisioning']
-    name: 'gcr.io/${PROJECT_ID}/ruby:2.3'
+    name: 'gcr.io/${PROJECT_ID}/ruby:2.5'
     entrypoint: bash
     args:
       - '-c'
@@ -42,7 +42,7 @@ steps:
   - id: completeTestSetup
     waitFor:
       - 'updateTestBundler'
-    name: 'gcr.io/${PROJECT_ID}/ruby:2.3'
+    name: 'gcr.io/${PROJECT_ID}/ruby:2.5'
     entrypoint: bash
 
   ###
@@ -51,7 +51,7 @@ steps:
 
   - id: runRspec
     waitFor: ['completeTestSetup']
-    name: 'gcr.io/${PROJECT_ID}/ruby:2.3'
+    name: 'gcr.io/${PROJECT_ID}/ruby:2.5'
     entrypoint: bash
     args:
       - '-c'

--- a/lib/subber/version.rb
+++ b/lib/subber/version.rb
@@ -1,3 +1,3 @@
 module Subber
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.3.3'.freeze
 end

--- a/subber.gemspec
+++ b/subber.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/viki-org/subber-gem"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.5'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
 
   # XML parser and builder
   #
-  spec.add_dependency "nokogiri", "~> 1.10.4"
+  spec.add_dependency "nokogiri", "~> 1.12.3"
 end

--- a/subber.gemspec
+++ b/subber.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 1.17.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.11"


### PR DESCRIPTION
## Asana Tasks:
- [Ops] Upgrade insecure gems for Community Services [[AsanaTask](https://app.asana.com/0/1179693510246913/1200860181337181/f)]

## What the reviewer should know:
https://github.com/advisories/GHSA-7rrm-v45f-jp64